### PR TITLE
Resolve "StartupSync doesn't work when all controlled goroutines have been initialized before the StartupSync call"

### DIFF
--- a/synchrozine.go
+++ b/synchrozine.go
@@ -69,6 +69,13 @@ func (s *Synchrozine) Inject(err error) {
 // StartupSync waits for all appended goroutines to start.
 func (s *Synchrozine) StartupSync(ctxFactory func() context.Context) error {
 	s.startMX.Lock()
+
+	if s.startCounter <= 0 {
+		s.startMX.Unlock()
+		ctxFactory() // initialize context to prevent runtime errors of canceling of nil context
+		return nil
+	}
+
 	s.waitingForStartup = true
 	s.startMX.Unlock()
 

--- a/synchrozine_test.go
+++ b/synchrozine_test.go
@@ -375,3 +375,21 @@ func TestSyncTimeoutExceeded(t *testing.T) {
 		t.Fatalf("Expected error is [%v], got [%v]\n", context.DeadlineExceeded, err)
 	}
 }
+
+func TestSyncStartupWithoutGoroutines(t *testing.T) {
+	synchro := New()
+	dur := 50 * time.Millisecond
+	var cancel context.CancelFunc
+	defer func() { cancel() }()
+
+	err := synchro.StartupSync(func() context.Context {
+		var ctx context.Context
+		ctx, cancel = context.WithTimeout(context.Background(), dur)
+
+		return ctx
+	})
+
+	if err != nil {
+		t.Fatalf("Expected error is [%v], got [%v]\n", nil, err)
+	}
+}


### PR DESCRIPTION
Close #11 